### PR TITLE
Bug Fix - Repeated fields have incorrect types

### DIFF
--- a/lib/clean-repeated.js
+++ b/lib/clean-repeated.js
@@ -20,7 +20,7 @@ const writer = fs.createWriteStream(tempFile, {
 });
 
 reader.on('line', (line) => {
-  if (/List.*Array</.test(line)) {
+  if (/List.*Array<.*>,/.test(line)) {
     writer.write(line.replace('List', ''));
   } else {
     writer.write(line);

--- a/lib/clean-repeated.js
+++ b/lib/clean-repeated.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const os = require('os');
+
+/**
+ * Read the generated lnrpc types and remove
+ * 'List' from all Array type names.
+ * More info:
+ * https://github.com/improbable-eng/ts-protoc-gen/issues/86
+ * https://github.com/protocolbuffers/protobuf/issues/4518
+ */
+
+const file = 'types/generated/rpc_pb.d.ts';
+const tempFile = 'types/generated/rpc_pb_temp.d.ts';
+
+const reader = require('readline').createInterface({
+  input: fs.createReadStream(file),
+});
+const writer = fs.createWriteStream(tempFile, {
+  flags: 'a',
+});
+
+reader.on('line', (line) => {
+  if (/List.*Array</.test(line)) {
+    writer.write(line.replace('List', ''));
+  } else {
+    writer.write(line);
+  }
+  writer.write(os.EOL);
+});
+
+reader.on('close', () => {
+  writer.end();
+
+  fs.renameSync(tempFile, file);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "./node_modules/.bin/eslint . && ./node_modules/.bin/mocha ./test/**/*.test.js",
     "start": "node ./index.js",
     "lint": "tslint -c tslint.json '{lib,test,types}/**/*.ts'",
-    "generate": "sh ./generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_protoc_version}",
+    "generate": "sh ./generate_types.sh ${npm_package_config_lnd_release_tag} ${npm_package_config_protoc_version} && node lib/clean-repeated.js",
     "postinstall": "git clone --depth 1 --branch ${npm_package_config_lnd_release_tag} ${npm_package_config_lnd_url} ./node_modules/lnd#${npm_package_config_lnd_release_tag} || true"
 
   },
@@ -28,7 +28,7 @@
   "author": "RadarTech",
   "license": "MIT",
   "dependencies": {
-    "@grpc/proto-loader": "^0.3.0",
+    "@grpc/proto-loader": "^0.4.0",
     "@types/google-protobuf": "^3.2.7",
     "grpc": "^1.14.0-pre2",
     "pkg-dir": "^2.0.0",

--- a/types/generated/rpc_pb.d.ts
+++ b/types/generated/rpc_pb.d.ts
@@ -34,8 +34,8 @@ export namespace GenSeedRequest {
 
 export class GenSeedResponse extends jspb.Message {
   clearCipherSeedMnemonicList(): void;
-  getCipherSeedMnemonicList(): Array<string>;
-  setCipherSeedMnemonicList(value: Array<string>): void;
+  getCipherSeedMnemonic(): Array<string>;
+  setCipherSeedMnemonic(value: Array<string>): void;
   addCipherSeedMnemonic(value: string, index?: number): string;
 
   getEncipheredSeed(): Uint8Array | string;
@@ -55,7 +55,7 @@ export class GenSeedResponse extends jspb.Message {
 
 export namespace GenSeedResponse {
   export type AsObject = {
-    cipherSeedMnemonicList: Array<string>,
+    cipherSeedMnemonic: Array<string>,
     encipheredSeed: Uint8Array | string,
   }
 }
@@ -67,8 +67,8 @@ export class InitWalletRequest extends jspb.Message {
   setWalletPassword(value: Uint8Array | string): void;
 
   clearCipherSeedMnemonicList(): void;
-  getCipherSeedMnemonicList(): Array<string>;
-  setCipherSeedMnemonicList(value: Array<string>): void;
+  getCipherSeedMnemonic(): Array<string>;
+  setCipherSeedMnemonic(value: Array<string>): void;
   addCipherSeedMnemonic(value: string, index?: number): string;
 
   getAezeedPassphrase(): Uint8Array | string;
@@ -92,7 +92,7 @@ export class InitWalletRequest extends jspb.Message {
 export namespace InitWalletRequest {
   export type AsObject = {
     walletPassword: Uint8Array | string,
-    cipherSeedMnemonicList: Array<string>,
+    cipherSeedMnemonic: Array<string>,
     aezeedPassphrase: Uint8Array | string,
     recoveryWindow: number,
   }
@@ -223,8 +223,8 @@ export class Transaction extends jspb.Message {
   setTotalFees(value: string): void;
 
   clearDestAddressesList(): void;
-  getDestAddressesList(): Array<string>;
-  setDestAddressesList(value: Array<string>): void;
+  getDestAddresses(): Array<string>;
+  setDestAddresses(value: Array<string>): void;
   addDestAddresses(value: string, index?: number): string;
 
   serializeBinary(): Uint8Array;
@@ -246,7 +246,7 @@ export namespace Transaction {
     blockHeight: number,
     timeStamp: string,
     totalFees: string,
-    destAddressesList: Array<string>,
+    destAddresses: Array<string>,
   }
 }
 
@@ -268,8 +268,8 @@ export namespace GetTransactionsRequest {
 
 export class TransactionDetails extends jspb.Message {
   clearTransactionsList(): void;
-  getTransactionsList(): Array<Transaction>;
-  setTransactionsList(value: Array<Transaction>): void;
+  getTransactions(): Array<Transaction>;
+  setTransactions(value: Array<Transaction>): void;
   addTransactions(value?: Transaction, index?: number): Transaction;
 
   serializeBinary(): Uint8Array;
@@ -284,7 +284,7 @@ export class TransactionDetails extends jspb.Message {
 
 export namespace TransactionDetails {
   export type AsObject = {
-    transactionsList: Array<Transaction.AsObject>,
+    transactions: Array<Transaction.AsObject>,
   }
 }
 
@@ -419,8 +419,8 @@ export class SendToRouteRequest extends jspb.Message {
   setPaymentHashString(value: string): void;
 
   clearRoutesList(): void;
-  getRoutesList(): Array<Route>;
-  setRoutesList(value: Array<Route>): void;
+  getRoutes(): Array<Route>;
+  setRoutes(value: Array<Route>): void;
   addRoutes(value?: Route, index?: number): Route;
 
   serializeBinary(): Uint8Array;
@@ -437,7 +437,7 @@ export namespace SendToRouteRequest {
   export type AsObject = {
     paymentHash: Uint8Array | string,
     paymentHashString: string,
-    routesList: Array<Route.AsObject>,
+    routes: Array<Route.AsObject>,
   }
 }
 
@@ -898,8 +898,8 @@ export class Channel extends jspb.Message {
   setNumUpdates(value: string): void;
 
   clearPendingHtlcsList(): void;
-  getPendingHtlcsList(): Array<HTLC>;
-  setPendingHtlcsList(value: Array<HTLC>): void;
+  getPendingHtlcs(): Array<HTLC>;
+  setPendingHtlcs(value: Array<HTLC>): void;
   addPendingHtlcs(value?: HTLC, index?: number): HTLC;
 
   getCsvDelay(): number;
@@ -934,7 +934,7 @@ export namespace Channel {
     totalSatoshisSent: string,
     totalSatoshisReceived: string,
     numUpdates: string,
-    pendingHtlcsList: Array<HTLC.AsObject>,
+    pendingHtlcs: Array<HTLC.AsObject>,
     csvDelay: number,
     pb_private: boolean,
   }
@@ -974,8 +974,8 @@ export namespace ListChannelsRequest {
 
 export class ListChannelsResponse extends jspb.Message {
   clearChannelsList(): void;
-  getChannelsList(): Array<Channel>;
-  setChannelsList(value: Array<Channel>): void;
+  getChannels(): Array<Channel>;
+  setChannels(value: Array<Channel>): void;
   addChannels(value?: Channel, index?: number): Channel;
 
   serializeBinary(): Uint8Array;
@@ -990,7 +990,7 @@ export class ListChannelsResponse extends jspb.Message {
 
 export namespace ListChannelsResponse {
   export type AsObject = {
-    channelsList: Array<Channel.AsObject>,
+    channels: Array<Channel.AsObject>,
   }
 }
 
@@ -1101,8 +1101,8 @@ export namespace ClosedChannelsRequest {
 
 export class ClosedChannelsResponse extends jspb.Message {
   clearChannelsList(): void;
-  getChannelsList(): Array<ChannelCloseSummary>;
-  setChannelsList(value: Array<ChannelCloseSummary>): void;
+  getChannels(): Array<ChannelCloseSummary>;
+  setChannels(value: Array<ChannelCloseSummary>): void;
   addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
 
   serializeBinary(): Uint8Array;
@@ -1117,7 +1117,7 @@ export class ClosedChannelsResponse extends jspb.Message {
 
 export namespace ClosedChannelsResponse {
   export type AsObject = {
-    channelsList: Array<ChannelCloseSummary.AsObject>,
+    channels: Array<ChannelCloseSummary.AsObject>,
   }
 }
 
@@ -1187,8 +1187,8 @@ export namespace ListPeersRequest {
 
 export class ListPeersResponse extends jspb.Message {
   clearPeersList(): void;
-  getPeersList(): Array<Peer>;
-  setPeersList(value: Array<Peer>): void;
+  getPeers(): Array<Peer>;
+  setPeers(value: Array<Peer>): void;
   addPeers(value?: Peer, index?: number): Peer;
 
   serializeBinary(): Uint8Array;
@@ -1203,7 +1203,7 @@ export class ListPeersResponse extends jspb.Message {
 
 export namespace ListPeersResponse {
   export type AsObject = {
-    peersList: Array<Peer.AsObject>,
+    peers: Array<Peer.AsObject>,
   }
 }
 
@@ -1252,13 +1252,13 @@ export class GetInfoResponse extends jspb.Message {
   setTestnet(value: boolean): void;
 
   clearChainsList(): void;
-  getChainsList(): Array<string>;
-  setChainsList(value: Array<string>): void;
+  getChains(): Array<string>;
+  setChains(value: Array<string>): void;
   addChains(value: string, index?: number): string;
 
   clearUrisList(): void;
-  getUrisList(): Array<string>;
-  setUrisList(value: Array<string>): void;
+  getUris(): Array<string>;
+  setUris(value: Array<string>): void;
   addUris(value: string, index?: number): string;
 
   getBestHeaderTimestamp(): string;
@@ -1291,8 +1291,8 @@ export namespace GetInfoResponse {
     blockHash: string,
     syncedToChain: boolean,
     testnet: boolean,
-    chainsList: Array<string>,
-    urisList: Array<string>,
+    chains: Array<string>,
+    uris: Array<string>,
     bestHeaderTimestamp: string,
     version: string,
     numInactiveChannels: number,
@@ -1644,23 +1644,23 @@ export class PendingChannelsResponse extends jspb.Message {
   setTotalLimboBalance(value: string): void;
 
   clearPendingOpenChannelsList(): void;
-  getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
-  setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
+  getPendingOpenChannels(): Array<PendingChannelsResponse.PendingOpenChannel>;
+  setPendingOpenChannels(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
   addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
 
   clearPendingClosingChannelsList(): void;
-  getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
-  setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
+  getPendingClosingChannels(): Array<PendingChannelsResponse.ClosedChannel>;
+  setPendingClosingChannels(value: Array<PendingChannelsResponse.ClosedChannel>): void;
   addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
 
   clearPendingForceClosingChannelsList(): void;
-  getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
-  setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
+  getPendingForceClosingChannels(): Array<PendingChannelsResponse.ForceClosedChannel>;
+  setPendingForceClosingChannels(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
   addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
 
   clearWaitingCloseChannelsList(): void;
-  getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
-  setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
+  getWaitingCloseChannels(): Array<PendingChannelsResponse.WaitingCloseChannel>;
+  setWaitingCloseChannels(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
   addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
 
   serializeBinary(): Uint8Array;
@@ -1676,10 +1676,10 @@ export class PendingChannelsResponse extends jspb.Message {
 export namespace PendingChannelsResponse {
   export type AsObject = {
     totalLimboBalance: string,
-    pendingOpenChannelsList: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
-    pendingClosingChannelsList: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
-    pendingForceClosingChannelsList: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
-    waitingCloseChannelsList: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
+    pendingOpenChannels: Array<PendingChannelsResponse.PendingOpenChannel.AsObject>,
+    pendingClosingChannels: Array<PendingChannelsResponse.ClosedChannel.AsObject>,
+    pendingForceClosingChannels: Array<PendingChannelsResponse.ForceClosedChannel.AsObject>,
+    waitingCloseChannels: Array<PendingChannelsResponse.WaitingCloseChannel.AsObject>,
   }
 
   export class PendingChannel extends jspb.Message {
@@ -1830,8 +1830,8 @@ export namespace PendingChannelsResponse {
     setRecoveredBalance(value: string): void;
 
     clearPendingHtlcsList(): void;
-    getPendingHtlcsList(): Array<PendingHTLC>;
-    setPendingHtlcsList(value: Array<PendingHTLC>): void;
+    getPendingHtlcs(): Array<PendingHTLC>;
+    setPendingHtlcs(value: Array<PendingHTLC>): void;
     addPendingHtlcs(value?: PendingHTLC, index?: number): PendingHTLC;
 
     serializeBinary(): Uint8Array;
@@ -1852,7 +1852,7 @@ export namespace PendingChannelsResponse {
       maturityHeight: number,
       blocksTilMaturity: number,
       recoveredBalance: string,
-      pendingHtlcsList: Array<PendingHTLC.AsObject>,
+      pendingHtlcs: Array<PendingHTLC.AsObject>,
     }
   }
 }
@@ -1981,8 +1981,8 @@ export namespace QueryRoutesRequest {
 
 export class QueryRoutesResponse extends jspb.Message {
   clearRoutesList(): void;
-  getRoutesList(): Array<Route>;
-  setRoutesList(value: Array<Route>): void;
+  getRoutes(): Array<Route>;
+  setRoutes(value: Array<Route>): void;
   addRoutes(value?: Route, index?: number): Route;
 
   serializeBinary(): Uint8Array;
@@ -1997,7 +1997,7 @@ export class QueryRoutesResponse extends jspb.Message {
 
 export namespace QueryRoutesResponse {
   export type AsObject = {
-    routesList: Array<Route.AsObject>,
+    routes: Array<Route.AsObject>,
   }
 }
 
@@ -2060,8 +2060,8 @@ export class Route extends jspb.Message {
   setTotalAmt(value: string): void;
 
   clearHopsList(): void;
-  getHopsList(): Array<Hop>;
-  setHopsList(value: Array<Hop>): void;
+  getHops(): Array<Hop>;
+  setHops(value: Array<Hop>): void;
   addHops(value?: Hop, index?: number): Hop;
 
   getTotalFeesMsat(): string;
@@ -2085,7 +2085,7 @@ export namespace Route {
     totalTimeLock: number,
     totalFees: string,
     totalAmt: string,
-    hopsList: Array<Hop.AsObject>,
+    hops: Array<Hop.AsObject>,
     totalFeesMsat: string,
     totalAmtMsat: string,
   }
@@ -2152,8 +2152,8 @@ export class LightningNode extends jspb.Message {
   setAlias(value: string): void;
 
   clearAddressesList(): void;
-  getAddressesList(): Array<NodeAddress>;
-  setAddressesList(value: Array<NodeAddress>): void;
+  getAddresses(): Array<NodeAddress>;
+  setAddresses(value: Array<NodeAddress>): void;
   addAddresses(value?: NodeAddress, index?: number): NodeAddress;
 
   getColor(): string;
@@ -2174,7 +2174,7 @@ export namespace LightningNode {
     lastUpdate: number,
     pubKey: string,
     alias: string,
-    addressesList: Array<NodeAddress.AsObject>,
+    addresses: Array<NodeAddress.AsObject>,
     color: string,
   }
 }
@@ -2313,13 +2313,13 @@ export namespace ChannelGraphRequest {
 
 export class ChannelGraph extends jspb.Message {
   clearNodesList(): void;
-  getNodesList(): Array<LightningNode>;
-  setNodesList(value: Array<LightningNode>): void;
+  getNodes(): Array<LightningNode>;
+  setNodes(value: Array<LightningNode>): void;
   addNodes(value?: LightningNode, index?: number): LightningNode;
 
   clearEdgesList(): void;
-  getEdgesList(): Array<ChannelEdge>;
-  setEdgesList(value: Array<ChannelEdge>): void;
+  getEdges(): Array<ChannelEdge>;
+  setEdges(value: Array<ChannelEdge>): void;
   addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
 
   serializeBinary(): Uint8Array;
@@ -2334,8 +2334,8 @@ export class ChannelGraph extends jspb.Message {
 
 export namespace ChannelGraph {
   export type AsObject = {
-    nodesList: Array<LightningNode.AsObject>,
-    edgesList: Array<ChannelEdge.AsObject>,
+    nodes: Array<LightningNode.AsObject>,
+    edges: Array<ChannelEdge.AsObject>,
   }
 }
 
@@ -2477,18 +2477,18 @@ export namespace GraphTopologySubscription {
 
 export class GraphTopologyUpdate extends jspb.Message {
   clearNodeUpdatesList(): void;
-  getNodeUpdatesList(): Array<NodeUpdate>;
-  setNodeUpdatesList(value: Array<NodeUpdate>): void;
+  getNodeUpdates(): Array<NodeUpdate>;
+  setNodeUpdates(value: Array<NodeUpdate>): void;
   addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
 
   clearChannelUpdatesList(): void;
-  getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
-  setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
+  getChannelUpdates(): Array<ChannelEdgeUpdate>;
+  setChannelUpdates(value: Array<ChannelEdgeUpdate>): void;
   addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
 
   clearClosedChansList(): void;
-  getClosedChansList(): Array<ClosedChannelUpdate>;
-  setClosedChansList(value: Array<ClosedChannelUpdate>): void;
+  getClosedChans(): Array<ClosedChannelUpdate>;
+  setClosedChans(value: Array<ClosedChannelUpdate>): void;
   addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
 
   serializeBinary(): Uint8Array;
@@ -2503,16 +2503,16 @@ export class GraphTopologyUpdate extends jspb.Message {
 
 export namespace GraphTopologyUpdate {
   export type AsObject = {
-    nodeUpdatesList: Array<NodeUpdate.AsObject>,
-    channelUpdatesList: Array<ChannelEdgeUpdate.AsObject>,
-    closedChansList: Array<ClosedChannelUpdate.AsObject>,
+    nodeUpdates: Array<NodeUpdate.AsObject>,
+    channelUpdates: Array<ChannelEdgeUpdate.AsObject>,
+    closedChans: Array<ClosedChannelUpdate.AsObject>,
   }
 }
 
 export class NodeUpdate extends jspb.Message {
   clearAddressesList(): void;
-  getAddressesList(): Array<string>;
-  setAddressesList(value: Array<string>): void;
+  getAddresses(): Array<string>;
+  setAddresses(value: Array<string>): void;
   addAddresses(value: string, index?: number): string;
 
   getIdentityKey(): string;
@@ -2538,7 +2538,7 @@ export class NodeUpdate extends jspb.Message {
 
 export namespace NodeUpdate {
   export type AsObject = {
-    addressesList: Array<string>,
+    addresses: Array<string>,
     identityKey: string,
     globalFeatures: Uint8Array | string,
     alias: string,
@@ -2661,8 +2661,8 @@ export namespace HopHint {
 
 export class RouteHint extends jspb.Message {
   clearHopHintsList(): void;
-  getHopHintsList(): Array<HopHint>;
-  setHopHintsList(value: Array<HopHint>): void;
+  getHopHints(): Array<HopHint>;
+  setHopHints(value: Array<HopHint>): void;
   addHopHints(value?: HopHint, index?: number): HopHint;
 
   serializeBinary(): Uint8Array;
@@ -2677,7 +2677,7 @@ export class RouteHint extends jspb.Message {
 
 export namespace RouteHint {
   export type AsObject = {
-    hopHintsList: Array<HopHint.AsObject>,
+    hopHints: Array<HopHint.AsObject>,
   }
 }
 
@@ -2730,8 +2730,8 @@ export class Invoice extends jspb.Message {
   setCltvExpiry(value: string): void;
 
   clearRouteHintsList(): void;
-  getRouteHintsList(): Array<RouteHint>;
-  setRouteHintsList(value: Array<RouteHint>): void;
+  getRouteHints(): Array<RouteHint>;
+  setRouteHints(value: Array<RouteHint>): void;
   addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
   getPrivate(): boolean;
@@ -2777,7 +2777,7 @@ export namespace Invoice {
     expiry: string,
     fallbackAddr: string,
     cltvExpiry: string,
-    routeHintsList: Array<RouteHint.AsObject>,
+    routeHints: Array<RouteHint.AsObject>,
     pb_private: boolean,
     addIndex: string,
     settleIndex: string,
@@ -2877,8 +2877,8 @@ export namespace ListInvoiceRequest {
 
 export class ListInvoiceResponse extends jspb.Message {
   clearInvoicesList(): void;
-  getInvoicesList(): Array<Invoice>;
-  setInvoicesList(value: Array<Invoice>): void;
+  getInvoices(): Array<Invoice>;
+  setInvoices(value: Array<Invoice>): void;
   addInvoices(value?: Invoice, index?: number): Invoice;
 
   getLastIndexOffset(): string;
@@ -2899,7 +2899,7 @@ export class ListInvoiceResponse extends jspb.Message {
 
 export namespace ListInvoiceResponse {
   export type AsObject = {
-    invoicesList: Array<Invoice.AsObject>,
+    invoices: Array<Invoice.AsObject>,
     lastIndexOffset: string,
     firstIndexOffset: string,
   }
@@ -2940,8 +2940,8 @@ export class Payment extends jspb.Message {
   setCreationDate(value: string): void;
 
   clearPathList(): void;
-  getPathList(): Array<string>;
-  setPathList(value: Array<string>): void;
+  getPath(): Array<string>;
+  setPath(value: Array<string>): void;
   addPath(value: string, index?: number): string;
 
   getFee(): string;
@@ -2971,7 +2971,7 @@ export namespace Payment {
     paymentHash: string,
     value: string,
     creationDate: string,
-    pathList: Array<string>,
+    path: Array<string>,
     fee: string,
     paymentPreimage: string,
     valueSat: string,
@@ -2997,8 +2997,8 @@ export namespace ListPaymentsRequest {
 
 export class ListPaymentsResponse extends jspb.Message {
   clearPaymentsList(): void;
-  getPaymentsList(): Array<Payment>;
-  setPaymentsList(value: Array<Payment>): void;
+  getPayments(): Array<Payment>;
+  setPayments(value: Array<Payment>): void;
   addPayments(value?: Payment, index?: number): Payment;
 
   serializeBinary(): Uint8Array;
@@ -3013,7 +3013,7 @@ export class ListPaymentsResponse extends jspb.Message {
 
 export namespace ListPaymentsResponse {
   export type AsObject = {
-    paymentsList: Array<Payment.AsObject>,
+    payments: Array<Payment.AsObject>,
   }
 }
 
@@ -3180,8 +3180,8 @@ export class PayReq extends jspb.Message {
   setCltvExpiry(value: string): void;
 
   clearRouteHintsList(): void;
-  getRouteHintsList(): Array<RouteHint>;
-  setRouteHintsList(value: Array<RouteHint>): void;
+  getRouteHints(): Array<RouteHint>;
+  setRouteHints(value: Array<RouteHint>): void;
   addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
   serializeBinary(): Uint8Array;
@@ -3205,7 +3205,7 @@ export namespace PayReq {
     descriptionHash: string,
     fallbackAddr: string,
     cltvExpiry: string,
-    routeHintsList: Array<RouteHint.AsObject>,
+    routeHints: Array<RouteHint.AsObject>,
   }
 }
 
@@ -3259,8 +3259,8 @@ export namespace ChannelFeeReport {
 
 export class FeeReportResponse extends jspb.Message {
   clearChannelFeesList(): void;
-  getChannelFeesList(): Array<ChannelFeeReport>;
-  setChannelFeesList(value: Array<ChannelFeeReport>): void;
+  getChannelFees(): Array<ChannelFeeReport>;
+  setChannelFees(value: Array<ChannelFeeReport>): void;
   addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
 
   getDayFeeSum(): string;
@@ -3284,7 +3284,7 @@ export class FeeReportResponse extends jspb.Message {
 
 export namespace FeeReportResponse {
   export type AsObject = {
-    channelFeesList: Array<ChannelFeeReport.AsObject>,
+    channelFees: Array<ChannelFeeReport.AsObject>,
     dayFeeSum: string,
     weekFeeSum: string,
     monthFeeSum: string,
@@ -3428,8 +3428,8 @@ export namespace ForwardingEvent {
 
 export class ForwardingHistoryResponse extends jspb.Message {
   clearForwardingEventsList(): void;
-  getForwardingEventsList(): Array<ForwardingEvent>;
-  setForwardingEventsList(value: Array<ForwardingEvent>): void;
+  getForwardingEvents(): Array<ForwardingEvent>;
+  setForwardingEvents(value: Array<ForwardingEvent>): void;
   addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
 
   getLastOffsetIndex(): number;
@@ -3447,7 +3447,7 @@ export class ForwardingHistoryResponse extends jspb.Message {
 
 export namespace ForwardingHistoryResponse {
   export type AsObject = {
-    forwardingEventsList: Array<ForwardingEvent.AsObject>,
+    forwardingEvents: Array<ForwardingEvent.AsObject>,
     lastOffsetIndex: number,
   }
 }

--- a/types/generated/rpc_pb.d.ts
+++ b/types/generated/rpc_pb.d.ts
@@ -34,8 +34,8 @@ export namespace GenSeedRequest {
 
 export class GenSeedResponse extends jspb.Message {
   clearCipherSeedMnemonicList(): void;
-  getCipherSeedMnemonic(): Array<string>;
-  setCipherSeedMnemonic(value: Array<string>): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
   addCipherSeedMnemonic(value: string, index?: number): string;
 
   getEncipheredSeed(): Uint8Array | string;
@@ -67,8 +67,8 @@ export class InitWalletRequest extends jspb.Message {
   setWalletPassword(value: Uint8Array | string): void;
 
   clearCipherSeedMnemonicList(): void;
-  getCipherSeedMnemonic(): Array<string>;
-  setCipherSeedMnemonic(value: Array<string>): void;
+  getCipherSeedMnemonicList(): Array<string>;
+  setCipherSeedMnemonicList(value: Array<string>): void;
   addCipherSeedMnemonic(value: string, index?: number): string;
 
   getAezeedPassphrase(): Uint8Array | string;
@@ -223,8 +223,8 @@ export class Transaction extends jspb.Message {
   setTotalFees(value: string): void;
 
   clearDestAddressesList(): void;
-  getDestAddresses(): Array<string>;
-  setDestAddresses(value: Array<string>): void;
+  getDestAddressesList(): Array<string>;
+  setDestAddressesList(value: Array<string>): void;
   addDestAddresses(value: string, index?: number): string;
 
   serializeBinary(): Uint8Array;
@@ -268,8 +268,8 @@ export namespace GetTransactionsRequest {
 
 export class TransactionDetails extends jspb.Message {
   clearTransactionsList(): void;
-  getTransactions(): Array<Transaction>;
-  setTransactions(value: Array<Transaction>): void;
+  getTransactionsList(): Array<Transaction>;
+  setTransactionsList(value: Array<Transaction>): void;
   addTransactions(value?: Transaction, index?: number): Transaction;
 
   serializeBinary(): Uint8Array;
@@ -419,8 +419,8 @@ export class SendToRouteRequest extends jspb.Message {
   setPaymentHashString(value: string): void;
 
   clearRoutesList(): void;
-  getRoutes(): Array<Route>;
-  setRoutes(value: Array<Route>): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
   addRoutes(value?: Route, index?: number): Route;
 
   serializeBinary(): Uint8Array;
@@ -898,8 +898,8 @@ export class Channel extends jspb.Message {
   setNumUpdates(value: string): void;
 
   clearPendingHtlcsList(): void;
-  getPendingHtlcs(): Array<HTLC>;
-  setPendingHtlcs(value: Array<HTLC>): void;
+  getPendingHtlcsList(): Array<HTLC>;
+  setPendingHtlcsList(value: Array<HTLC>): void;
   addPendingHtlcs(value?: HTLC, index?: number): HTLC;
 
   getCsvDelay(): number;
@@ -974,8 +974,8 @@ export namespace ListChannelsRequest {
 
 export class ListChannelsResponse extends jspb.Message {
   clearChannelsList(): void;
-  getChannels(): Array<Channel>;
-  setChannels(value: Array<Channel>): void;
+  getChannelsList(): Array<Channel>;
+  setChannelsList(value: Array<Channel>): void;
   addChannels(value?: Channel, index?: number): Channel;
 
   serializeBinary(): Uint8Array;
@@ -1101,8 +1101,8 @@ export namespace ClosedChannelsRequest {
 
 export class ClosedChannelsResponse extends jspb.Message {
   clearChannelsList(): void;
-  getChannels(): Array<ChannelCloseSummary>;
-  setChannels(value: Array<ChannelCloseSummary>): void;
+  getChannelsList(): Array<ChannelCloseSummary>;
+  setChannelsList(value: Array<ChannelCloseSummary>): void;
   addChannels(value?: ChannelCloseSummary, index?: number): ChannelCloseSummary;
 
   serializeBinary(): Uint8Array;
@@ -1187,8 +1187,8 @@ export namespace ListPeersRequest {
 
 export class ListPeersResponse extends jspb.Message {
   clearPeersList(): void;
-  getPeers(): Array<Peer>;
-  setPeers(value: Array<Peer>): void;
+  getPeersList(): Array<Peer>;
+  setPeersList(value: Array<Peer>): void;
   addPeers(value?: Peer, index?: number): Peer;
 
   serializeBinary(): Uint8Array;
@@ -1252,13 +1252,13 @@ export class GetInfoResponse extends jspb.Message {
   setTestnet(value: boolean): void;
 
   clearChainsList(): void;
-  getChains(): Array<string>;
-  setChains(value: Array<string>): void;
+  getChainsList(): Array<string>;
+  setChainsList(value: Array<string>): void;
   addChains(value: string, index?: number): string;
 
   clearUrisList(): void;
-  getUris(): Array<string>;
-  setUris(value: Array<string>): void;
+  getUrisList(): Array<string>;
+  setUrisList(value: Array<string>): void;
   addUris(value: string, index?: number): string;
 
   getBestHeaderTimestamp(): string;
@@ -1644,23 +1644,23 @@ export class PendingChannelsResponse extends jspb.Message {
   setTotalLimboBalance(value: string): void;
 
   clearPendingOpenChannelsList(): void;
-  getPendingOpenChannels(): Array<PendingChannelsResponse.PendingOpenChannel>;
-  setPendingOpenChannels(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
+  getPendingOpenChannelsList(): Array<PendingChannelsResponse.PendingOpenChannel>;
+  setPendingOpenChannelsList(value: Array<PendingChannelsResponse.PendingOpenChannel>): void;
   addPendingOpenChannels(value?: PendingChannelsResponse.PendingOpenChannel, index?: number): PendingChannelsResponse.PendingOpenChannel;
 
   clearPendingClosingChannelsList(): void;
-  getPendingClosingChannels(): Array<PendingChannelsResponse.ClosedChannel>;
-  setPendingClosingChannels(value: Array<PendingChannelsResponse.ClosedChannel>): void;
+  getPendingClosingChannelsList(): Array<PendingChannelsResponse.ClosedChannel>;
+  setPendingClosingChannelsList(value: Array<PendingChannelsResponse.ClosedChannel>): void;
   addPendingClosingChannels(value?: PendingChannelsResponse.ClosedChannel, index?: number): PendingChannelsResponse.ClosedChannel;
 
   clearPendingForceClosingChannelsList(): void;
-  getPendingForceClosingChannels(): Array<PendingChannelsResponse.ForceClosedChannel>;
-  setPendingForceClosingChannels(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
+  getPendingForceClosingChannelsList(): Array<PendingChannelsResponse.ForceClosedChannel>;
+  setPendingForceClosingChannelsList(value: Array<PendingChannelsResponse.ForceClosedChannel>): void;
   addPendingForceClosingChannels(value?: PendingChannelsResponse.ForceClosedChannel, index?: number): PendingChannelsResponse.ForceClosedChannel;
 
   clearWaitingCloseChannelsList(): void;
-  getWaitingCloseChannels(): Array<PendingChannelsResponse.WaitingCloseChannel>;
-  setWaitingCloseChannels(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
+  getWaitingCloseChannelsList(): Array<PendingChannelsResponse.WaitingCloseChannel>;
+  setWaitingCloseChannelsList(value: Array<PendingChannelsResponse.WaitingCloseChannel>): void;
   addWaitingCloseChannels(value?: PendingChannelsResponse.WaitingCloseChannel, index?: number): PendingChannelsResponse.WaitingCloseChannel;
 
   serializeBinary(): Uint8Array;
@@ -1830,8 +1830,8 @@ export namespace PendingChannelsResponse {
     setRecoveredBalance(value: string): void;
 
     clearPendingHtlcsList(): void;
-    getPendingHtlcs(): Array<PendingHTLC>;
-    setPendingHtlcs(value: Array<PendingHTLC>): void;
+    getPendingHtlcsList(): Array<PendingHTLC>;
+    setPendingHtlcsList(value: Array<PendingHTLC>): void;
     addPendingHtlcs(value?: PendingHTLC, index?: number): PendingHTLC;
 
     serializeBinary(): Uint8Array;
@@ -1981,8 +1981,8 @@ export namespace QueryRoutesRequest {
 
 export class QueryRoutesResponse extends jspb.Message {
   clearRoutesList(): void;
-  getRoutes(): Array<Route>;
-  setRoutes(value: Array<Route>): void;
+  getRoutesList(): Array<Route>;
+  setRoutesList(value: Array<Route>): void;
   addRoutes(value?: Route, index?: number): Route;
 
   serializeBinary(): Uint8Array;
@@ -2060,8 +2060,8 @@ export class Route extends jspb.Message {
   setTotalAmt(value: string): void;
 
   clearHopsList(): void;
-  getHops(): Array<Hop>;
-  setHops(value: Array<Hop>): void;
+  getHopsList(): Array<Hop>;
+  setHopsList(value: Array<Hop>): void;
   addHops(value?: Hop, index?: number): Hop;
 
   getTotalFeesMsat(): string;
@@ -2152,8 +2152,8 @@ export class LightningNode extends jspb.Message {
   setAlias(value: string): void;
 
   clearAddressesList(): void;
-  getAddresses(): Array<NodeAddress>;
-  setAddresses(value: Array<NodeAddress>): void;
+  getAddressesList(): Array<NodeAddress>;
+  setAddressesList(value: Array<NodeAddress>): void;
   addAddresses(value?: NodeAddress, index?: number): NodeAddress;
 
   getColor(): string;
@@ -2313,13 +2313,13 @@ export namespace ChannelGraphRequest {
 
 export class ChannelGraph extends jspb.Message {
   clearNodesList(): void;
-  getNodes(): Array<LightningNode>;
-  setNodes(value: Array<LightningNode>): void;
+  getNodesList(): Array<LightningNode>;
+  setNodesList(value: Array<LightningNode>): void;
   addNodes(value?: LightningNode, index?: number): LightningNode;
 
   clearEdgesList(): void;
-  getEdges(): Array<ChannelEdge>;
-  setEdges(value: Array<ChannelEdge>): void;
+  getEdgesList(): Array<ChannelEdge>;
+  setEdgesList(value: Array<ChannelEdge>): void;
   addEdges(value?: ChannelEdge, index?: number): ChannelEdge;
 
   serializeBinary(): Uint8Array;
@@ -2477,18 +2477,18 @@ export namespace GraphTopologySubscription {
 
 export class GraphTopologyUpdate extends jspb.Message {
   clearNodeUpdatesList(): void;
-  getNodeUpdates(): Array<NodeUpdate>;
-  setNodeUpdates(value: Array<NodeUpdate>): void;
+  getNodeUpdatesList(): Array<NodeUpdate>;
+  setNodeUpdatesList(value: Array<NodeUpdate>): void;
   addNodeUpdates(value?: NodeUpdate, index?: number): NodeUpdate;
 
   clearChannelUpdatesList(): void;
-  getChannelUpdates(): Array<ChannelEdgeUpdate>;
-  setChannelUpdates(value: Array<ChannelEdgeUpdate>): void;
+  getChannelUpdatesList(): Array<ChannelEdgeUpdate>;
+  setChannelUpdatesList(value: Array<ChannelEdgeUpdate>): void;
   addChannelUpdates(value?: ChannelEdgeUpdate, index?: number): ChannelEdgeUpdate;
 
   clearClosedChansList(): void;
-  getClosedChans(): Array<ClosedChannelUpdate>;
-  setClosedChans(value: Array<ClosedChannelUpdate>): void;
+  getClosedChansList(): Array<ClosedChannelUpdate>;
+  setClosedChansList(value: Array<ClosedChannelUpdate>): void;
   addClosedChans(value?: ClosedChannelUpdate, index?: number): ClosedChannelUpdate;
 
   serializeBinary(): Uint8Array;
@@ -2511,8 +2511,8 @@ export namespace GraphTopologyUpdate {
 
 export class NodeUpdate extends jspb.Message {
   clearAddressesList(): void;
-  getAddresses(): Array<string>;
-  setAddresses(value: Array<string>): void;
+  getAddressesList(): Array<string>;
+  setAddressesList(value: Array<string>): void;
   addAddresses(value: string, index?: number): string;
 
   getIdentityKey(): string;
@@ -2661,8 +2661,8 @@ export namespace HopHint {
 
 export class RouteHint extends jspb.Message {
   clearHopHintsList(): void;
-  getHopHints(): Array<HopHint>;
-  setHopHints(value: Array<HopHint>): void;
+  getHopHintsList(): Array<HopHint>;
+  setHopHintsList(value: Array<HopHint>): void;
   addHopHints(value?: HopHint, index?: number): HopHint;
 
   serializeBinary(): Uint8Array;
@@ -2730,8 +2730,8 @@ export class Invoice extends jspb.Message {
   setCltvExpiry(value: string): void;
 
   clearRouteHintsList(): void;
-  getRouteHints(): Array<RouteHint>;
-  setRouteHints(value: Array<RouteHint>): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
   addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
   getPrivate(): boolean;
@@ -2877,8 +2877,8 @@ export namespace ListInvoiceRequest {
 
 export class ListInvoiceResponse extends jspb.Message {
   clearInvoicesList(): void;
-  getInvoices(): Array<Invoice>;
-  setInvoices(value: Array<Invoice>): void;
+  getInvoicesList(): Array<Invoice>;
+  setInvoicesList(value: Array<Invoice>): void;
   addInvoices(value?: Invoice, index?: number): Invoice;
 
   getLastIndexOffset(): string;
@@ -2940,8 +2940,8 @@ export class Payment extends jspb.Message {
   setCreationDate(value: string): void;
 
   clearPathList(): void;
-  getPath(): Array<string>;
-  setPath(value: Array<string>): void;
+  getPathList(): Array<string>;
+  setPathList(value: Array<string>): void;
   addPath(value: string, index?: number): string;
 
   getFee(): string;
@@ -2997,8 +2997,8 @@ export namespace ListPaymentsRequest {
 
 export class ListPaymentsResponse extends jspb.Message {
   clearPaymentsList(): void;
-  getPayments(): Array<Payment>;
-  setPayments(value: Array<Payment>): void;
+  getPaymentsList(): Array<Payment>;
+  setPaymentsList(value: Array<Payment>): void;
   addPayments(value?: Payment, index?: number): Payment;
 
   serializeBinary(): Uint8Array;
@@ -3180,8 +3180,8 @@ export class PayReq extends jspb.Message {
   setCltvExpiry(value: string): void;
 
   clearRouteHintsList(): void;
-  getRouteHints(): Array<RouteHint>;
-  setRouteHints(value: Array<RouteHint>): void;
+  getRouteHintsList(): Array<RouteHint>;
+  setRouteHintsList(value: Array<RouteHint>): void;
   addRouteHints(value?: RouteHint, index?: number): RouteHint;
 
   serializeBinary(): Uint8Array;
@@ -3259,8 +3259,8 @@ export namespace ChannelFeeReport {
 
 export class FeeReportResponse extends jspb.Message {
   clearChannelFeesList(): void;
-  getChannelFees(): Array<ChannelFeeReport>;
-  setChannelFees(value: Array<ChannelFeeReport>): void;
+  getChannelFeesList(): Array<ChannelFeeReport>;
+  setChannelFeesList(value: Array<ChannelFeeReport>): void;
   addChannelFees(value?: ChannelFeeReport, index?: number): ChannelFeeReport;
 
   getDayFeeSum(): string;
@@ -3428,8 +3428,8 @@ export namespace ForwardingEvent {
 
 export class ForwardingHistoryResponse extends jspb.Message {
   clearForwardingEventsList(): void;
-  getForwardingEvents(): Array<ForwardingEvent>;
-  setForwardingEvents(value: Array<ForwardingEvent>): void;
+  getForwardingEventsList(): Array<ForwardingEvent>;
+  setForwardingEventsList(value: Array<ForwardingEvent>): void;
   addForwardingEvents(value?: ForwardingEvent, index?: number): ForwardingEvent;
 
   getLastOffsetIndex(): number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,12 @@
 # yarn lockfile v1
 
 
-"@grpc/proto-loader@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.3.0.tgz#c127d3859bff895f220453612ba04b923af0c584"
-  integrity sha512-9b8S/V+3W4Gv7G/JKSZ48zApgyYbfIR7mAC9XNnaSWme3zj57MIESu0ELzm9j5oxNIpFG8DgO00iJMIUZ5luqw==
+"@grpc/proto-loader@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.4.0.tgz#a823a51eb2fde58369bef1deb5445fd808d70901"
+  integrity sha512-Jm6o+75uWT7E6+lt8edg4J1F/9+BedOjaMgwE14pxS/AO43/0ZqK+rCLVVrXLoExwSAZvgvOD2B0ivy3Spsspw==
   dependencies:
-    "@types/lodash" "^4.14.104"
-    "@types/node" "^9.4.6"
-    lodash "^4.17.5"
+    lodash.camelcase "^4.3.0"
     protobufjs "^6.8.6"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
@@ -70,11 +68,6 @@
   resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.2.7.tgz#9576ed5dd62cdb1c9f952522028a03b7cb2b69b5"
   integrity sha512-Pb9wl5qDEwfnJeeu6Zpn5Y+waLrKETStqLZXHMGCTbkNuBBudPy4qOGN6veamyeoUBwTm2knOVeP/FlHHhhmzA==
 
-"@types/lodash@^4.14.104":
-  version "4.14.120"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
-  integrity sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==
-
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -84,11 +77,6 @@
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
-
-"@types/node@^9.4.6":
-  version "9.6.41"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.41.tgz#e57c3152eb2e7ec748c733cebd0c095b437c5d37"
-  integrity sha512-sPZWEbFMz6qAy9SLY7jh5cgepmsiwqUUHjvEm8lpU6kug2hmmcyuTnwhoGw/GWpI5Npue4EqvsiQQI0eWjW/ZA==
 
 abbrev@1:
   version "1.1.1"
@@ -851,7 +839,7 @@ lodash.clone@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
-lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
The generated types were incorrect for repeated fields. The type generation process was adding List to the end of the variable names.

`describegraph` example:

Proto:
```
message ChannelGraph {
    /// The list of `LightningNode`s in this channel graph
    repeated LightningNode nodes = 1 [json_name = "nodes"];

    /// The list of `ChannelEdge`s in this channel graph
    repeated ChannelEdge edges = 2 [json_name = "edges"];
}
```

Generated:

```
export namespace ChannelGraph {
  export type AsObject = {
    nodesList: Array<LightningNode.AsObject>,
    edgesList: Array<ChannelEdge.AsObject>,
  }
}
```

This PR adds a script, which will be run at the end of the type generation process. This will remove `List` from the generated type names. As of now, I haven't been able to find an easier way to prevent this behavior.