### PR TITLE
Return longs as strings

### DIFF
--- a/lib/lnrpc.js
+++ b/lib/lnrpc.js
@@ -138,7 +138,9 @@ module.exports = async function createLnRpc(config = {}) {
   let grpcPkgObj;
 
   try {
-    const packageDefinition = await grpcLoader.load(protoDest);
+    const packageDefinition = await grpcLoader.load(protoDest, {
+      longs: String,
+    });
     grpcPkgObj = grpc.loadPackageDefinition(packageDefinition);
   } catch (e) {
     if (!e.code) e.code = 'GRPC_LOAD_ERR';


### PR DESCRIPTION
The type defs specify that longs should be returned as strings. However, they are currently being returned as `Long` objects. This PR aligns the returned value with the type.