### PR TITLE
Typed Streams

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,11 @@
 import { LnRpcClientConfig } from "./config";
 import { LnRpc } from "./lnrpc";
+import { Duplex, Readable } from "./streams";
 
 declare module "@radar/lnrpc" {
   export * from "./config";
   export * from "./lnrpc";
+  export * from "./streams";
 
   function createLnRpc(config: LnRpcClientConfig): Promise<LnRpc>;
   export = createLnRpc;

--- a/types/streams/duplex.d.ts
+++ b/types/streams/duplex.d.ts
@@ -1,0 +1,36 @@
+import { Writable, WritableOptions } from "stream";
+import { Readable, ReadableOptions } from "./readable";
+
+declare class Duplex<REQ = any, RES = any> extends Readable<RES> implements Writable {
+  public writable: boolean;
+  public readonly writableHighWaterMark: number;
+  public readonly writableLength: number;
+  constructor(opts?: DuplexOptions<REQ, RES>);
+  public _write(chunk: REQ, encoding: string, callback: (error?: Error | null) => void): void;
+  public _writev?(chunks: Array<{ chunk: REQ, encoding: string }>, callback: (error?: Error | null) => void): void;
+  public _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+  public _final(callback: (error?: Error | null) => void): void;
+  public write(chunk: REQ, cb?: (error: Error | null | undefined) => void): boolean;
+  public write(chunk: REQ, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
+  public setDefaultEncoding(encoding: string): this;
+  public end(cb?: () => void): void;
+  public end(chunk: any, cb?: () => void): void;
+  public end(chunk: any, encoding?: string, cb?: () => void): void;
+  public cork(): void;
+  public uncork(): void;
+}
+
+export interface DuplexOptions<REQ, RES> extends ReadableOptions<RES>, WritableOptions {
+  allowHalfOpen?: boolean;
+  readableObjectMode?: boolean;
+  writableObjectMode?: boolean;
+  read?(this: Duplex<REQ, RES>, size: number): void;
+  write?(this: Duplex<REQ, RES>, chunk: REQ, encoding: string, callback: (error?: Error | null) => void): void;
+  writev?(
+    this: Duplex<REQ, RES>,
+    chunks: Array<{ chunk: REQ, encoding: string }>,
+    callback: (error?: Error | null) => void,
+  ): void;
+  final?(this: Duplex<REQ, RES>, callback: (error?: Error | null) => void): void;
+  destroy?(this: Duplex<REQ, RES>, error: Error | null, callback: (error: Error | null) => void): void;
+}

--- a/types/streams/duplex.d.ts
+++ b/types/streams/duplex.d.ts
@@ -14,8 +14,8 @@ declare class Duplex<REQ = any, RES = any> extends Readable<RES> implements Writ
   public write(chunk: REQ, encoding?: string, cb?: (error: Error | null | undefined) => void): boolean;
   public setDefaultEncoding(encoding: string): this;
   public end(cb?: () => void): void;
-  public end(chunk: any, cb?: () => void): void;
-  public end(chunk: any, encoding?: string, cb?: () => void): void;
+  public end(chunk: REQ, cb?: () => void): void;
+  public end(chunk: REQ, encoding?: string, cb?: () => void): void;
   public cork(): void;
   public uncork(): void;
 }

--- a/types/streams/index.d.ts
+++ b/types/streams/index.d.ts
@@ -1,0 +1,2 @@
+export { Duplex } from "./duplex";
+export { Readable } from "./readable";

--- a/types/streams/readable.d.ts
+++ b/types/streams/readable.d.ts
@@ -1,0 +1,74 @@
+import { Stream } from "stream";
+
+declare class Readable<RES = any> extends Stream implements NodeJS.ReadableStream {
+  public readable: boolean;
+  public readonly readableHighWaterMark: number;
+  public readonly readableLength: number;
+  constructor(opts?: ReadableOptions<RES>);
+  public _read(size: number): void;
+  public read(size?: number): string | Buffer;
+  public setEncoding(encoding: string): this;
+  public pause(): this;
+  public resume(): this;
+  public isPaused(): boolean;
+  public unpipe<T extends NodeJS.WritableStream>(destination?: T): this;
+  public unshift(chunk: string | Buffer): void;
+  public wrap(oldStream: NodeJS.ReadableStream): this;
+  public push(chunk: RES, encoding?: string): boolean;
+  public _destroy(error: Error | null, callback: (error: Error | null) => void): void;
+  public destroy(error?: Error): void;
+
+  /**
+   * Event emitter
+   * The defined events on documents including:
+   * 1. close
+   * 2. data
+   * 3. end
+   * 4. readable
+   * 5. error
+   */
+  public addListener(event: "close" | "end" | "readable", listener: () => void): this;
+  public addListener(event: "data", listener: (chunk: RES) => void): this;
+  public addListener(event: "error", listener: (err: Error) => void): this;
+  public addListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public emit(event: "close" | "end" | "readable"): boolean;
+  public emit(event: "data", chunk: RES): boolean;
+  public emit(event: "error", err: Error): boolean;
+  public emit(event: string | symbol, ...args: any[]): boolean;
+
+  public on(event: "close" | "end" | "readable", listener: () => void): this;
+  public on(event: "data", listener: (chunk: RES) => void): this;
+  public on(event: "error", listener: (err: Error) => void): this;
+  public on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public once(event: "close" | "end" | "readable", listener: () => void): this;
+  public once(event: "data", listener: (chunk: RES) => void): this;
+  public once(event: "error", listener: (err: Error) => void): this;
+  public once(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public prependListener(event: "close" | "end" | "readable", listener: () => void): this;
+  public prependListener(event: "data", listener: (chunk: RES) => void): this;
+  public prependListener(event: "error", listener: (err: Error) => void): this;
+  public prependListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public prependOnceListener(event: "close" | "end" | "readable", listener: () => void): this;
+  public prependOnceListener(event: "data", listener: (chunk: RES) => void): this;
+  public prependOnceListener(event: "error", listener: (err: Error) => void): this;
+  public prependOnceListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public removeListener(event: "close" | "end" | "readable", listener: () => void): this;
+  public removeListener(event: "data", listener: (chunk: RES) => void): this;
+  public removeListener(event: "error", listener: (err: Error) => void): this;
+  public removeListener(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  public [Symbol.asyncIterator](): AsyncIterableIterator<RES>;
+}
+
+export interface ReadableOptions<RES> {
+  highWaterMark?: number;
+  encoding?: string;
+  objectMode?: boolean;
+  read?(this: Readable<RES>, size: number): void;
+  destroy?(this: Readable<RES>, error: Error | null, callback: (error: Error | null) => void): void;
+}


### PR DESCRIPTION
This PR implements typed streams; resolving https://github.com/RadarTech/lnrpc/issues/29. Strongly typed readable and duplex stream events offer a much better developer experience when using subscription-based calls.