### PR TITLE
Audit Job Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
     - *dependencies
     - run: 
         name: Run Audit
-        command: yarn audit
+        command: |
+          sudo npm install -g yarn
+          yarn audit --groups dependencies
   test-node-8:
     docker:
     - image: circleci/node:8


### PR DESCRIPTION
This updates the audit job to target the `dependencies` group only. 

This requires `yarn` to be `1.16` and above. 