### PR TITLE
Fix QueryRoutesRequest Type

### DIFF
--- a/types/lnrpc.d.ts
+++ b/types/lnrpc.d.ts
@@ -711,9 +711,9 @@ export interface QueryRoutesRequest {
   numRoutes?: number;
   finalCltvDelta?: number;
   feeLimit?: FeeLimit;
-  ignoredNodes: Buffer[] | string[];
-  ignoredEdges: EdgeLocator[];
-  sourcePubKey: string;
+  ignoredNodes?: Buffer[] | string[];
+  ignoredEdges?: EdgeLocator[];
+  sourcePubKey?: string;
 }
 
 export interface QueryRoutesResponse {


### PR DESCRIPTION
This PR fixes the `QueryRoutesRequest` type by adding optional modifiers where necessary (according to the LND documentation). This resolves https://github.com/RadarTech/lnrpc/issues/40.