### PR TITLE
Lightning node addresses should be an array

### DIFF
--- a/types/lnrpc.d.ts
+++ b/types/lnrpc.d.ts
@@ -232,7 +232,7 @@ export interface LightningNode {
   lastUpdate: number;
   pubKey: string;
   alias: string;
-  addresses: NodeAddress;
+  addresses: NodeAddress[];
   color: string;
 }
 


### PR DESCRIPTION
This PR corrects the `addresses` property type in the `LightningNode` interface