### PR TITLE
FIX: closeChannel argument passing

### DIFF
--- a/lib/lightning.js
+++ b/lib/lightning.js
@@ -67,7 +67,12 @@ module.exports = function createLightningProxy(
         return target[key]; // forward
       } else {
         if (subscriptionMethods.includes(key)) {
-          return defaultEmptyArg(method);
+          switch (method.originalName) {
+            case 'closeChannel':
+              return method;
+            default:
+              return defaultEmptyArg(method);
+          }
         }
         return promisify(defaultEmptyArg(method));
       }

--- a/types/lnrpc.d.ts
+++ b/types/lnrpc.d.ts
@@ -174,8 +174,8 @@ export interface ChannelCloseSummary {
 }
 
 export interface FeeLimit {
-  fixed: string;
-  percent: string;
+  fixed?: string;
+  percent?: string;
 }
 
 export interface Hop {


### PR DESCRIPTION
`defaultEmptyArg` does not work correctly with `closeChannel`. It causes args to be passed in the wrong parameter. Further investigation is needed. This PR acts as a quick fix.