### PR TITLE
Fix ChannelPoint interface

### DIFF
--- a/types/lnrpc.d.ts
+++ b/types/lnrpc.d.ts
@@ -509,8 +509,8 @@ export interface OpenStatusUpdate {
 }
 
 export interface ChannelPoint {
-  fundingTxidBytes: Buffer | string;
-  fundingTxidStr: string;
+  fundingTxidBytes?: Buffer | string;
+  fundingTxidStr?: string;
   outputIndex: number;
 }
 


### PR DESCRIPTION
The `ChannelPoint` interface should not require both `fundingTxidBytes` and `fundingTxidStr`. This interface is included in multiple request payloads, which means that the caller would need to provide both or cast to avoid typescript errors.

This PR resolves https://github.com/RadarTech/lnrpc/issues/54.