### PR TITLE
Remove Runtime File Rewriting

### DIFF
--- a/lib/lnrpc.js
+++ b/lib/lnrpc.js
@@ -7,8 +7,8 @@ const GRPC = require('grpc');
 const createLightning = require('./lightning');
 const createWalletUnlocker = require('./wallet-unlocker');
 const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-const stat = promisify(fs.stat);
+const protobufjs = require('protobufjs');
+const path = require('path');
 const packageJson = require('../package.json');
 
 const HOME_DIR = require('os').homedir();
@@ -37,11 +37,10 @@ const DEFAULTS = {
  */
 module.exports = async function createLnRpc(config = {}) {
   const rootPath = await pkgDir(__dirname);
-  const protoSrc = join(
+  const protoFile = join(
     rootPath,
     `lnd/${packageJson.config['lnd-release-tag']}/rpc.proto`,
   );
-  const protoDest = join(rootPath, 'rpc.proto');
 
   /*
    Configuration options
@@ -121,20 +120,6 @@ module.exports = async function createLnRpc(config = {}) {
     );
   }
 
-  /*
-   Write `rpc.proto` if none exists
-   */
-  try {
-    await stat(protoDest);
-  } catch (e) {
-    // file doesn't exist
-    let grpcSrc = await readFile(protoSrc, 'utf8');
-
-    // remove google annotations causing parse error on `grpc.load()`
-    grpcSrc = grpcSrc.replace('import "google/api/annotations.proto";', '');
-    await writeFile(protoDest, grpcSrc);
-  }
-
   /**
    * Create RPC from proto and return GRPC
    * @type {grpc.PackageDefinition}
@@ -142,7 +127,13 @@ module.exports = async function createLnRpc(config = {}) {
   let grpcPkgObj;
 
   try {
-    const packageDefinition = await grpcLoader.load(protoDest, {
+    // Prevent google annotations from causing parse error on `grpc.load()`
+    protobufjs.common(
+      `${path.dirname(protoFile)}/google/api/annotations.proto`,
+      {},
+    );
+
+    const packageDefinition = await grpcLoader.load(protoFile, {
       longs: String,
     });
     grpcPkgObj = grpc.loadPackageDefinition(packageDefinition);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/google-protobuf": "^3.2.7",
     "grpc": "^1.19.0",
     "pkg-dir": "^2.0.0",
+    "protobufjs": "^6.8.8",
     "ts-protoc-gen": "^0.8.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,7 +1113,7 @@ protobufjs@^5.0.3:
     glob "^7.0.5"
     yargs "^3.10.0"
 
-protobufjs@^6.8.6:
+protobufjs@^6.8.6, protobufjs@^6.8.8:
   version "6.8.8"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
   integrity sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==


### PR DESCRIPTION
It's not possible to rewrite the proto file at runtime when using this library in a packaged electron app. Instead, we'll use `protobuf.common()` to provide an empty custom type to fix the issue without the need to rewrite or duplicate the proto file.

This PR resolves https://github.com/RadarTech/lnrpc/issues/56.