### PR TITLE
Remove default cipher suite when no cert is passed

### DIFF
--- a/lib/lnrpc.js
+++ b/lib/lnrpc.js
@@ -72,7 +72,8 @@ module.exports = async function createLnRpc(config = {}) {
       cert = Buffer.from(cert, certEncoding);
     }
 
-    // Required for lnd SSL handshake when a cert is provided: (SSL_ERROR_SSL: error:14094410)
+    // Required for lnd SSL handshake when a cert is provided:
+    // (SSL_ERROR_SSL: error:14094410)
     // More about GRPC environment variables here:
     // https://grpc.io/grpc/core/md_doc_environment_variables.html
     if (cert && !process.env.GRPC_SSL_CIPHER_SUITES) {

--- a/lib/lnrpc.js
+++ b/lib/lnrpc.js
@@ -72,12 +72,10 @@ module.exports = async function createLnRpc(config = {}) {
       cert = Buffer.from(cert, certEncoding);
     }
 
-    /*
-     Required for lnd SSL handshake: (SSL_ERROR_SSL: error:14094410)
-     More about GRPC environment variables here:
-     https://grpc.io/grpc/core/md_doc_environment_variables.html
-    */
-    if (!process.env.GRPC_SSL_CIPHER_SUITES) {
+    // Required for lnd SSL handshake when a cert is provided: (SSL_ERROR_SSL: error:14094410)
+    // More about GRPC environment variables here:
+    // https://grpc.io/grpc/core/md_doc_environment_variables.html
+    if (cert && !process.env.GRPC_SSL_CIPHER_SUITES) {
       process.env.GRPC_SSL_CIPHER_SUITES = 'HIGH+ECDSA';
     }
 


### PR DESCRIPTION
A different cipher suite may be used when interfacing with BTCPay server. Setting the cipher suite to `HIGH+ECDSA` in this scenario causes a SSL handshake failure.

To fix this, only default the cipher suite if a cert is provided and no suite is set.