### PR TITLE
Fix 'subscribeSingleInvoice' argument passing

### DIFF
--- a/src/services/invoices.ts
+++ b/src/services/invoices.ts
@@ -15,6 +15,7 @@ export function createInvoices(config: ConnectionConfig): any {
     const subscriptionMethods: SubscriptionMethod[] = [
       {
         name: 'subscribeSingleInvoice',
+        skipEmptyArgDefault: true,
       },
     ];
 


### PR DESCRIPTION
This PR fixes `subscribeSingleInvoice` argument passing by skipping empty argument defaulting. Resolves https://github.com/RadarTech/lnrpc/issues/65.