### PR TITLE
Optional flag to include default values

### DIFF
--- a/src/rpc/autopilot-rpc.ts
+++ b/src/rpc/autopilot-rpc.ts
@@ -31,13 +31,14 @@ export async function createAutopilotRpc<T = unknown>(userConfig: AutopilotRpcCl
     ...defaults,
     ...userConfig,
   };
-  const { autopilot, server, grpcLoader, grpc } = config;
+  const { autopilot, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/chain-rpc.ts
+++ b/src/rpc/chain-rpc.ts
@@ -31,13 +31,14 @@ export async function createChainRpc<T = unknown>(userConfig: ChainRpcClientConf
     ...defaults,
     ...userConfig,
   };
-  const { chainNotifier, server, grpcLoader, grpc } = config;
+  const { chainNotifier, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/create-grpc-object.ts
+++ b/src/rpc/create-grpc-object.ts
@@ -6,9 +6,10 @@ import { GrpcObjectConfig, NestedGrpcObject } from '../types';
  */
 export function createGrpcObject(config: GrpcObjectConfig) {
   try {
-    const { protoFilePath, includeDirs, grpcLoader, grpc } = config;
+    const { protoFilePath, includeDirs, grpcLoader, grpc, includeDefaults } = config;
     const packageDefinition = grpcLoader.loadSync(protoFilePath, {
       longs: String,
+      defaults: includeDefaults ?? false,
       includeDirs,
     });
     return grpc.loadPackageDefinition(packageDefinition) as NestedGrpcObject;

--- a/src/rpc/invoices-rpc.ts
+++ b/src/rpc/invoices-rpc.ts
@@ -35,13 +35,14 @@ export async function createInvoicesRpc<T = unknown>(userConfig: InvoicesRpcClie
     ...defaults,
     ...userConfig,
   };
-  const { invoices, server, grpcLoader, grpc } = config;
+  const { invoices, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/ln-rpc.ts
+++ b/src/rpc/ln-rpc.ts
@@ -31,13 +31,14 @@ export async function createLnRpc<T extends unknown>(userConfig: LnRpcClientConf
     ...defaults,
     ...userConfig,
   };
-  const { lightning, walletUnlocker, server, grpcLoader, grpc } = config;
+  const { lightning, walletUnlocker, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/router-rpc.ts
+++ b/src/rpc/router-rpc.ts
@@ -35,13 +35,14 @@ export async function createRouterRpc<T = unknown>(userConfig: RouterRpcClientCo
     ...defaults,
     ...userConfig,
   };
-  const { router, server, grpcLoader, grpc } = config;
+  const { router, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/sign-rpc.ts
+++ b/src/rpc/sign-rpc.ts
@@ -31,13 +31,14 @@ export async function createSignRpc<T = unknown>(userConfig: SignRpcClientConfig
     ...defaults,
     ...userConfig,
   };
-  const { signer, server, grpcLoader, grpc } = config;
+  const { signer, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/wallet-rpc.ts
+++ b/src/rpc/wallet-rpc.ts
@@ -35,13 +35,14 @@ export async function createWalletRpc<T = unknown>(userConfig: WalletRpcClientCo
     ...defaults,
     ...userConfig,
   };
-  const { walletKit, server, grpcLoader, grpc } = config;
+  const { walletKit, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/watchtower-rpc.ts
+++ b/src/rpc/watchtower-rpc.ts
@@ -33,13 +33,14 @@ export async function createWatchtowerRpc<T = unknown>(
     ...defaults,
     ...userConfig,
   };
-  const { watchtower, server, grpcLoader, grpc } = config;
+  const { watchtower, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/rpc/wt-client-rpc.ts
+++ b/src/rpc/wt-client-rpc.ts
@@ -31,13 +31,14 @@ export async function createWtClientRpc<T = unknown>(userConfig: WtClientRpcClie
     ...defaults,
     ...userConfig,
   };
-  const { watchtowerClient, server, grpcLoader, grpc } = config;
+  const { watchtowerClient, server, grpcLoader, grpc, includeDefaults } = config;
 
   // Generate grpc SSL credentials
   const credentials = await createCredentials(config);
 
   // Create RPC from proto and return GRPC
   const grpcPkgObj = createGrpcObject({
+    includeDefaults,
     protoFilePath,
     grpcLoader,
     grpc,

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -32,6 +32,7 @@ export interface GrpcObjectConfig {
   includeDirs?: string[];
   grpcLoader: GrpcLoader;
   grpc: Grpc;
+  includeDefaults?: boolean;
 }
 
 export interface RpcClientConfig {
@@ -43,6 +44,7 @@ export interface RpcClientConfig {
   certEncoding?: string; // Default to utf-8
   grpcLoader?: GrpcLoader;
   grpc?: Grpc;
+  includeDefaults?: boolean; // Whether default values should be included in gRPC responses. Defaults to false.
 }
 
 export interface AutopilotRpcClientConfig extends RpcClientConfig {


### PR DESCRIPTION
This PR allows the consumer of this library to optionally enable the inclusion of default values in gRPC responses, resolving https://github.com/RadarTech/lnrpc/issues/64.

By default, these values are stripped from responses. Unfortunately, this has the side effect of removing falsy values that the consumer may want in the response, like an enum member with a value of 0. This change allows the consumer to optionally enable the inclusion of these values.