### PR TITLE
Fix New RouterRPC Streaming Methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ yarn generate
 Newly generated type definitions will be available in `./generated`.
 You can now delete the old proto file inside the lnd directory.
 Use the generated type definitions to update the types in `src/types/rpc`.
+Any added streaming methods must be included in the `subscriptionMethods` array that's into the `createServiceClient` function.
+This prevents streaming methods from being promisified.
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radar/lnrpc",
-  "version": "v0.10.0-beta",
+  "version": "v0.10.0-beta.0",
   "description": "A Typescript gRPC client for LND with support for all LND sub-servers",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/services/router.ts
+++ b/src/services/router.ts
@@ -13,6 +13,9 @@ export function createRouter(config: ConnectionConfig): any {
       credentials,
     );
     const subscriptionMethods = [
+      'sendPaymentV2',
+      'trackPaymentV2',
+      'subscribeHtlcEvents',
       'sendPayment',
       'trackPayment',
     ];


### PR DESCRIPTION
This PR adds the new routerrpc streaming methods to the `subscriptionMethods` array, which prevents them from being promisified. This resolves https://github.com/RadarTech/lnrpc/issues/76.